### PR TITLE
Update IntervalTable.sc

### DIFF
--- a/classes/IntervalTable.sc
+++ b/classes/IntervalTable.sc
@@ -17,7 +17,7 @@ IntervalTable {
 	
 	*loadTable {|type = \JST, min = \030, path |
 		var ark, filename;
-		path = path ?? {Platform.userAppSupportDir ++ "/quarks/DissonanceLib/"};
+		path = path ?? {Platform.userAppSupportDir ++ "/downloaded-quarks/DissonanceLib/"};
 		tableType = type;
 		if (type == \huygens) {tableMin = nil} {tableMin = min};
 		type.switch(


### PR DESCRIPTION
Supercollider now creates the folder downloaded-quarks rather than the deprecated quarks; this correction in the code allows the DissonanceLib to function with current versions of SuperCollider (3.9.xxx)