### PR TITLE
fixed _ArrayCat error

### DIFF
--- a/classes/HarmonicMetric.sc
+++ b/classes/HarmonicMetric.sc
@@ -42,7 +42,8 @@ HarmonicMetric {
 		^ratios[order]
 	}
 	
-	asString { ^type }	
+	asString { ^type.asString
+	}
 
 }
 


### PR DESCRIPTION
```
*** Welcome to SuperCollider 3.11.2. *** For help press Cmd-D.
ERROR: Primitive '_ArrayCat' failed.
Wrong type.
RECEIVER:
Instance of String {    (0x1131eee40, gc=01, fmt=07, flg=11, set=02)
  indexed slots [3]
      0 : -
      1 : >
      2 :  
}
CALL STACK:
	MethodError:reportError
		arg this = <instance of PrimitiveFailedError>
	Nil:handleError
		arg this = nil
		arg error = <instance of PrimitiveFailedError>
	Thread:handleError
		arg this = <instance of Thread>
		arg error = <instance of PrimitiveFailedError>
	Object:throw
		arg this = <instance of PrimitiveFailedError>
	Object:primitiveFailed
		arg this = "-> "
	Interpreter:interpretPrintCmdLine
		arg this = <instance of Interpreter>
		var res = <instance of HarmonicMetricCS>
		var func = <instance of Function>
		var code = "x = HarmonicMetricCS.new;"
		var doc = nil
		var ideClass = <instance of Meta_ScIDE>
	Process:interpretPrintCmdLine
		arg this = <instance of Main>
^^ The preceding error dump is for ERROR: Primitive '_ArrayCat' failed.
Wrong type.
RECEIVER: -> 

```